### PR TITLE
Simplify api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ setup: ## Install all the build and lint dependencies
 	go get -u github.com/pierrre/gotestcover
 	go get -u golang.org/x/tools/cmd/cover
 	go get -u code.cloudfoundry.org/go-diodes
+	go get -u github.com/stretchr/testify/require
 	gometalinter --install --update
 
 test: ## Run all the tests

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ setup: ## Install all the build and lint dependencies
 	go get -u github.com/alecthomas/gometalinter
 	go get -u github.com/pierrre/gotestcover
 	go get -u golang.org/x/tools/cmd/cover
-	go get -u code.cloudfoundry.org/go-diodes
 	go get -u github.com/stretchr/testify/require
 	gometalinter --install --update
 

--- a/hub_example_test.go
+++ b/hub_example_test.go
@@ -14,11 +14,7 @@ func ExampleHub() {
 	// If you wan an unbuferred channel use the 0 cap
 	sub := h.Subscribe("account.*.failed", 10)
 	go func(s *hub.Subscription) {
-		for {
-			msg, ok := sub.Subscriber.Next()
-			if !ok {
-				break
-			}
+		for msg := range s.Receiver {
 			fmt.Printf("receive msg with topic %s and id %d\n", msg.Name, msg.Int("id"))
 		}
 	}(sub)

--- a/hub_test.go
+++ b/hub_test.go
@@ -42,19 +42,15 @@ func TestProcessSubscribers(t *testing.T) {
 }
 
 func TestNonBlockingSubscriberShouldAlertIfLoseMessages(t *testing.T) {
-	t.Skip()
 	h := New()
-	subs := h.NonBlockingSubscribe("a.*.c", 10)
+	h.NonBlockingSubscribe("a.*.c", 10)
 	subsAlert := h.Subscribe(AlertTopic, 1)
 	// send messages without a working subscriber
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 11; i++ {
 		h.Publish(Message{Name: "a.c.c", Fields: Fields{"i": i}})
 	}
-	msg := <-subs.Receiver
-	// next message will be the last published - cap
-	require.Equal(t, 90, msg.Int("i"))
-	msg = <-subsAlert.Receiver
-	require.Equal(t, 90, msg.Int("missed"))
+	msg := <-subsAlert.Receiver
+	require.Equal(t, 1, msg.Int("missed"))
 	require.Equal(t, "a.*.c", msg.String("topic"))
 }
 

--- a/matching.go
+++ b/matching.go
@@ -20,21 +20,32 @@ const (
 	wildcard  = "*"
 )
 
-// Subscription represents a topic subscription.
-type Subscription struct {
-	id         uint32
-	Topic      string
-	Subscriber Subscriber
-}
+type (
+	// Subscription represents a topic subscription.
+	Subscription struct {
+		Topic      string
+		Receiver   <-chan Message
+		subscriber subscriber
+	}
 
-// Matcher contains topic subscriptions and performs matches on them.
-type Matcher interface {
+	// subscriber is the interface used internally to send values and get the channel used by subscribers.
+	// This is used to override the behaviour of channel and support nonBlocking operations
+	subscriber interface {
+		// Set send the given Event to be processed by the subscriber
+		Set(Message)
+		// Ch return the channel used to consume messages inside the subscription
+		Ch() <-chan Message
+	}
+)
+
+// matcher contains topic subscriptions and performs matches on them.
+type matcher interface {
 	// Subscribe adds the Subscriber to the topic and returns a Subscription.
-	Subscribe(topic string, sub Subscriber) *Subscription
+	Subscribe(topic string, sub subscriber) *Subscription
 
 	// Unsubscribe removes the Subscription.
 	Unsubscribe(sub *Subscription)
 
-	// Lookup returns the SubscrMultithreaded4Threadibers for the given topic.
-	Lookup(topic string) []Subscriber
+	// Lookup returns the subscribers for the given topic.
+	Lookup(topic string) []subscriber
 }

--- a/matching_cstrie_test.go
+++ b/matching_cstrie_test.go
@@ -38,11 +38,11 @@ func TestCSTrieMatcher(t *testing.T) {
 	sub5 := m.Subscribe("trade", s1)
 	sub6 := m.Subscribe("*", s2)
 
-	assertEqual(assert, []Subscriber{s0, s1}, m.Lookup("forex.eur"))
-	assertEqual(assert, []Subscriber{s2}, m.Lookup("forex"))
-	assertEqual(assert, []Subscriber{}, m.Lookup("trade.jpy"))
-	assertEqual(assert, []Subscriber{s0, s1}, m.Lookup("forex.jpy"))
-	assertEqual(assert, []Subscriber{s1, s2}, m.Lookup("trade"))
+	assertEqual(assert, []subscriber{s0, s1}, m.Lookup("forex.eur"))
+	assertEqual(assert, []subscriber{s2}, m.Lookup("forex"))
+	assertEqual(assert, []subscriber{}, m.Lookup("trade.jpy"))
+	assertEqual(assert, []subscriber{s0, s1}, m.Lookup("forex.jpy"))
+	assertEqual(assert, []subscriber{s1, s2}, m.Lookup("trade"))
 
 	m.Unsubscribe(sub0)
 	m.Unsubscribe(sub1)
@@ -52,11 +52,11 @@ func TestCSTrieMatcher(t *testing.T) {
 	m.Unsubscribe(sub5)
 	m.Unsubscribe(sub6)
 
-	assertEqual(assert, []Subscriber{}, m.Lookup("forex.eur"))
-	assertEqual(assert, []Subscriber{}, m.Lookup("forex"))
-	assertEqual(assert, []Subscriber{}, m.Lookup("trade.jpy"))
-	assertEqual(assert, []Subscriber{}, m.Lookup("forex.jpy"))
-	assertEqual(assert, []Subscriber{}, m.Lookup("trade"))
+	assertEqual(assert, []subscriber{}, m.Lookup("forex.eur"))
+	assertEqual(assert, []subscriber{}, m.Lookup("forex"))
+	assertEqual(assert, []subscriber{}, m.Lookup("trade.jpy"))
+	assertEqual(assert, []subscriber{}, m.Lookup("forex.jpy"))
+	assertEqual(assert, []subscriber{}, m.Lookup("trade"))
 }
 
 func BenchmarkCSTrieMatcherSubscribe(b *testing.B) {

--- a/utils_test.go
+++ b/utils_test.go
@@ -26,10 +26,10 @@ import (
 
 type discardSubscriber int
 
-func (d discardSubscriber) Set(msg Message)       {}
-func (d discardSubscriber) Next() (Message, bool) { return Message{}, false }
+func (d discardSubscriber) Set(msg Message)    {}
+func (d discardSubscriber) Ch() <-chan Message { return make(chan Message) }
 
-func benchmarkMatcher(b *testing.B, numItems, numThreads int, m Matcher, doSubs func(n int) bool) {
+func benchmarkMatcher(b *testing.B, numItems, numThreads int, m matcher, doSubs func(n int) bool) {
 	itemsToInsert := generateTopics(numThreads, numItems)
 
 	var wg sync.WaitGroup
@@ -63,7 +63,7 @@ func percentual9010(n int) bool {
 	return n%10 == 0
 }
 
-func assertEqual(assert *assert.Assertions, expected, actual []Subscriber) {
+func assertEqual(assert *assert.Assertions, expected, actual []subscriber) {
 	assert.Len(actual, len(expected))
 	for _, sub := range expected {
 		assert.Contains(actual, sub)
@@ -83,7 +83,7 @@ func generateTopics(numThreads, numItems int) [][]string {
 	return itemsToInsert
 }
 
-func populateMatcher(m Matcher, num, topicSize int) {
+func populateMatcher(m matcher, num, topicSize int) {
 	for i := 0; i < num; i++ {
 		prefix := ""
 		topic := ""


### PR DESCRIPTION
I removed the Subscriber exported interface and change the Subscription
to have a channel instead
The nonBlockingSubscriber was changed and instead of an ring buffer we
will use one channel as well
This simplified the api and removed the only dependency of this library
but this cost in terms of performance. This will not be a problem
because this software should not be the hot path of a program