### PR TITLE
add multiple topic subscribers

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ func main() {
 	var wg sync.WaitGroup
 	// the cap param is used to create one buffered channel with cap = 10
 	// If you wan an unbuferred channel use the 0 cap
-	sub := h.Subscribe("account.*.failed", 10)
+	sub := h.Subscribe(10, "account.login.*", "account.changepassword.*")
 	wg.Add(1)
 	go func(s hub.Subscription) {
 		for msg := range s.Receiver {
@@ -83,11 +83,16 @@ func main() {
 		Fields: hub.Fields{"id": 456},
 	})
 	h.Publish(hub.Message{
+		Name:   "account.login.success",
+		Fields: hub.Fields{"id": 123},
+	})
+	// message not routed to this subscriber
+	h.Publish(hub.Message{
 		Name:   "account.foo.failed",
 		Fields: hub.Fields{"id": 789},
 	})
 
-	// finish all the subscribers
+	// close all the subscribers
 	h.Close()
 	// wait until finish all the messages on buffer
 	wg.Wait()
@@ -95,7 +100,7 @@ func main() {
 	// Output:
 	// receive msg with topic account.login.failed and id 123
 	// receive msg with topic account.changepassword.failed and id 456
-	// receive msg with topic account.foo.failed and id 789
+	// receive msg with topic account.login.success and id 123
 }
 ```
 See more [here](https://godoc.org/github.com/leandro-lugaresi/hub#example-Hub)!
@@ -127,6 +132,9 @@ ok      github.com/leandro-lugaresi/hub 3.192s
 ## CSTrie
 
 This project uses internally an awesome Concurrent Subscription Trie done by [@tylertreat](https://github.com/tylertreat). If you want to learn more about see this [blog post](http://bravenewgeek.com/fast-topic-matching/) and the code is [here](https://github.com/tylertreat/fast-topic-matching)
+
+
+
 ---
 
 This project adheres to the Contributor Covenant [code of conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.

--- a/hub_example_test.go
+++ b/hub_example_test.go
@@ -12,7 +12,7 @@ func ExampleHub() {
 	var wg sync.WaitGroup
 	// the cap param is used to create one buffered channel with cap = 10
 	// If you wan an unbuferred channel use the 0 cap
-	sub := h.Subscribe("account.*.failed", 10)
+	sub := h.Subscribe(10, "account.login.*", "account.changepassword.*")
 	wg.Add(1)
 	go func(s hub.Subscription) {
 		for msg := range s.Receiver {
@@ -30,11 +30,16 @@ func ExampleHub() {
 		Fields: hub.Fields{"id": 456},
 	})
 	h.Publish(hub.Message{
+		Name:   "account.login.success",
+		Fields: hub.Fields{"id": 123},
+	})
+	// message not routed to this subscriber
+	h.Publish(hub.Message{
 		Name:   "account.foo.failed",
 		Fields: hub.Fields{"id": 789},
 	})
 
-	// finish all the subscribers
+	// close all the subscribers
 	h.Close()
 	// wait until finish all the messages on buffer
 	wg.Wait()
@@ -42,5 +47,5 @@ func ExampleHub() {
 	// Output:
 	// receive msg with topic account.login.failed and id 123
 	// receive msg with topic account.changepassword.failed and id 456
-	// receive msg with topic account.foo.failed and id 789
+	// receive msg with topic account.login.success and id 123
 }

--- a/matching.go
+++ b/matching.go
@@ -23,7 +23,7 @@ const (
 type (
 	// Subscription represents a topic subscription.
 	Subscription struct {
-		Topic      string
+		Topics     []string
 		Receiver   <-chan Message
 		subscriber subscriber
 	}
@@ -45,8 +45,8 @@ type (
 
 // matcher contains topic subscriptions and performs matches on them.
 type matcher interface {
-	// Subscribe adds the Subscriber to the topic and returns a Subscription.
-	Subscribe(topic string, sub subscriber) Subscription
+	// Subscribe adds the Subscriber to the topics and returns a Subscription.
+	Subscribe(topics []string, sub subscriber) Subscription
 
 	// Unsubscribe removes the Subscription.
 	Unsubscribe(sub Subscription)

--- a/matching_cstrie_test.go
+++ b/matching_cstrie_test.go
@@ -30,13 +30,13 @@ func TestCSTrieMatcher(t *testing.T) {
 		s2 = discardSubscriber(2)
 	)
 
-	sub0 := m.Subscribe("forex.*", s0)
-	sub1 := m.Subscribe("*.usd", s0)
-	sub2 := m.Subscribe("forex.eur", s0)
-	sub3 := m.Subscribe("*.eur", s1)
-	sub4 := m.Subscribe("forex.*", s1)
-	sub5 := m.Subscribe("trade", s1)
-	sub6 := m.Subscribe("*", s2)
+	sub0 := m.Subscribe([]string{"forex.*"}, s0)
+	sub1 := m.Subscribe([]string{"*.usd"}, s0)
+	sub2 := m.Subscribe([]string{"forex.eur"}, s0)
+	sub3 := m.Subscribe([]string{"*.eur"}, s1)
+	sub4 := m.Subscribe([]string{"forex.*"}, s1)
+	sub5 := m.Subscribe([]string{"trade"}, s1)
+	sub6 := m.Subscribe([]string{"*"}, s2)
 	assert.Len(m.Subscriptions(), 7)
 
 	assertEqual(assert, []subscriber{s0, s1}, m.Lookup("forex.eur"))
@@ -69,7 +69,7 @@ func BenchmarkCSTrieMatcherSubscribe(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		m.Subscribe("foo.*.baz.qux.quux", s0)
+		m.Subscribe([]string{"foo.*.baz.qux.quux"}, s0)
 	}
 }
 
@@ -78,7 +78,7 @@ func BenchmarkCSTrieMatcherUnsubscribe(b *testing.B) {
 		m  = newCSTrieMatcher()
 		s0 = discardSubscriber(0)
 	)
-	id := m.Subscribe("foo.*.baz.qux.quux", s0)
+	id := m.Subscribe([]string{"foo.*.baz.qux.quux"}, s0)
 	populateMatcher(m, 1000, 5)
 
 	b.ResetTimer()
@@ -92,7 +92,7 @@ func BenchmarkCSTrieMatcherLookup(b *testing.B) {
 		m  = newCSTrieMatcher()
 		s0 = discardSubscriber(0)
 	)
-	m.Subscribe("foo.*.baz.qux.quux", s0)
+	m.Subscribe([]string{"foo.*.baz.qux.quux"}, s0)
 	populateMatcher(m, 1000, 5)
 
 	b.ResetTimer()
@@ -109,7 +109,7 @@ func BenchmarkCSTrieMatcherSubscribeCold(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		m.Subscribe("foo.*.baz.qux.quux", s0)
+		m.Subscribe([]string{"foo.*.baz.qux.quux"}, s0)
 	}
 }
 
@@ -118,7 +118,7 @@ func BenchmarkCSTrieMatcherUnsubscribeCold(b *testing.B) {
 		m  = newCSTrieMatcher()
 		s0 = discardSubscriber(0)
 	)
-	id := m.Subscribe("foo.*.baz.qux.quux", s0)
+	id := m.Subscribe([]string{"foo.*.baz.qux.quux"}, s0)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -131,7 +131,7 @@ func BenchmarkCSTrieMatcherLookupCold(b *testing.B) {
 		m  = newCSTrieMatcher()
 		s0 = discardSubscriber(0)
 	)
-	m.Subscribe("foo.*.baz.qux.quux", s0)
+	m.Subscribe([]string{"foo.*.baz.qux.quux"}, s0)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/throughput_test.go
+++ b/throughput_test.go
@@ -51,7 +51,7 @@ func TestThroughput(t *testing.T) {
 	}
 	var wg sync.WaitGroup
 	for _, topic := range topics {
-		sub := h.Subscribe(topic, 200)
+		sub := h.Subscribe(200, topic)
 		go func(s Subscription) {
 			for range s.Receiver {
 			}

--- a/utils_test.go
+++ b/utils_test.go
@@ -44,7 +44,7 @@ func benchmarkMatcher(b *testing.B, numItems, numThreads int, m matcher, doSubs 
 			go func(j int) {
 				for n, key := range itemsToInsert[j] {
 					if doSubs(n) {
-						m.Subscribe(key, sub)
+						m.Subscribe([]string{key}, sub)
 						continue
 					}
 					m.Lookup(key)
@@ -92,6 +92,6 @@ func populateMatcher(m matcher, num, topicSize int) {
 			topic += prefix + strconv.Itoa(rand.Int())
 			prefix = "."
 		}
-		m.Subscribe(topic, discardSubscriber(0))
+		m.Subscribe([]string{topic}, discardSubscriber(0))
 	}
 }


### PR DESCRIPTION
in some cases, the subscribers need to subscribe to multiple topics
and the `*` isn`t enough.

Now all the subscribers can subscribe to multiple topics.
Reducing the use of select from multiple channels