### PR TITLE
Fix panic on closed channel

### DIFF
--- a/hub_test.go
+++ b/hub_test.go
@@ -125,16 +125,12 @@ func TestCloseBlockingSubscriber(t *testing.T) {
 	wg := sync.WaitGroup{}
 
 	go func() {
-		for {
-			_, ok := <-sub.Receiver
-			if !ok {
-				return
-			}
+		for range sub.Receiver {
 		}
 	}()
 
 	wg.Add(100)
-	for i := 0; i < 100; i ++ {
+	for i := 0; i < 100; i++ {
 		go func() {
 			defer wg.Done()
 			h.Publish(Message{Name: "topic"})
@@ -145,7 +141,6 @@ func TestCloseBlockingSubscriber(t *testing.T) {
 	wg.Wait()
 }
 
-
 func TestCloseNonBlockingSubscriber(t *testing.T) {
 	h := New()
 
@@ -153,16 +148,12 @@ func TestCloseNonBlockingSubscriber(t *testing.T) {
 	wg := sync.WaitGroup{}
 
 	go func() {
-		for {
-			_, ok := <-sub.Receiver
-			if !ok {
-				return
-			}
+		for range sub.Receiver {
 		}
 	}()
 
 	wg.Add(100)
-	for i := 0; i < 100; i ++ {
+	for i := 0; i < 100; i++ {
 		go func() {
 			defer wg.Done()
 			h.Publish(Message{Name: "topic"})

--- a/subscriber.go
+++ b/subscriber.go
@@ -97,10 +97,7 @@ func (s *blockingSubscriber) Set(msg Message) {
 	default:
 	}
 
-	select {
-	case s.ch <- msg:
-	case <-s.closeCh:
-	}
+	s.ch <- msg
 }
 
 // Ch return the channel used by subscriptions to consume messages.

--- a/subscriber.go
+++ b/subscriber.go
@@ -4,10 +4,10 @@ type (
 	alertFunc func(missed int)
 
 	nonBlockingSubscriber struct {
-		ch        chan Message
+		ch    chan Message
 		input chan Message
 		close chan struct{}
-		alert     alertFunc
+		alert alertFunc
 	}
 	// blockingSubscriber uses an channel to receive events.
 	blockingSubscriber struct {
@@ -27,8 +27,8 @@ func newNonBlockingSubscriber(cap int, alerter alertFunc) *nonBlockingSubscriber
 
 	sub := &nonBlockingSubscriber{
 		ch:    make(chan Message, 1),
-		close:    make(chan struct{}, 1),
-		input:    make(chan Message, cap),
+		close: make(chan struct{}, 1),
+		input: make(chan Message, cap),
 		alert: alerter,
 	}
 

--- a/subscriber.go
+++ b/subscriber.go
@@ -90,14 +90,10 @@ func (s *blockingSubscriber) Set(msg Message) {
 	s.chMu.RLock()
 	defer s.chMu.RUnlock()
 
-	// check s.ch isn't closed (we are holding the RLock, so s.ch won't be closed until the end of this function)
 	select {
+	case s.ch <- msg:
 	case <-s.closeCh:
-		return
-	default:
 	}
-
-	s.ch <- msg
 }
 
 // Ch return the channel used by subscriptions to consume messages.


### PR DESCRIPTION
# Fix panic in subscribers

When hub publishes messages, it first finds all matching subscribers and then calls `sub.Set(m)` on them:
```go
// Publish will send an event to all the subscribers matching the event name.
func (h *Hub) Publish(m Message) {
	for k, v := range h.fields {
		m.Fields[k] = v
	}

	for _, sub := range h.matcher.Lookup(m.Topic()) {
		sub.Set(m)
	}
}
```

However, if `Unsubscribe` is called after the filtering but before the `Set`, the subscriber's underlying channel is closed and `Set` tries to write into a closed channel.

This PR adds channels and goroutines responsible for closing the channel.