### PR TITLE
update workflows to work on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         run: make setup
 
       - name: Tests
-        run: make integration-ci
+        run: make test
 
       - name: Send coverage
         uses: codecov/codecov-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,14 @@
-name: Push
-on: [push]
+name: Pull Request CI Check
+on: [push, pull_request]
 jobs:
   build:
-    name: Test
+    name: Run Tests
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.13
+      - name: Set up Go 1.15
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.15
         id: go
 
       - name: Go env
@@ -17,17 +17,16 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
 
-      - name: Get dependencies
+      - name: Setup
         run: make setup
 
       - name: Tests
-        run: make test
+        run: make integration-ci
 
-      - name: Upload coverage to Codecov
+      - name: Send coverage
         uses: codecov/codecov-action@v1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.txt
           flags: unittests
           name: codecov-umbrella
-          fail_ci_if_error: true
+          fail_ci_if_error: false

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,7 +1,5 @@
 name: reviewdog
-on:
-  pull_request:
-
+on: [pull_request]
 jobs:
   golangci-lint:
     name: runner / golangci-lint
@@ -12,7 +10,7 @@ jobs:
       - name: golangci-lint
         uses: docker://reviewdog/action-golangci-lint:v1.6 # Pre-built image
         with:
-          github_token: ${{ secrets.HUB_TOKEN }}
+          github_token: ${{ secrets.github_token }}
           golangci_lint_flags: "--config=.golangci.yml -D golint -D errcheck"
           reporter: github-pr-review
 
@@ -26,7 +24,7 @@ jobs:
       - name: golint
         uses: reviewdog/action-golangci-lint@v1
         with:
-          github_token: ${{ secrets.HUB_TOKEN }}
+          github_token: ${{ secrets.github_token }}
           golangci_lint_flags: "--disable-all -E golint"
           tool_name: golint # Change reporter name.
           level: error
@@ -41,7 +39,7 @@ jobs:
       - name: errcheck
         uses: reviewdog/action-golangci-lint@v1
         with:
-          github_token: ${{ secrets.HUB_TOKEN }}
+          github_token: ${{ secrets.github_token }}
           golangci_lint_flags: "--disable-all -E errcheck"
           tool_name: errcheck
           level: warning
@@ -54,7 +52,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: reviewdog/action-staticcheck@v1
         with:
-          github_token: ${{ secrets.HUB_TOKEN }}
+          github_token: ${{ secrets.github_token }}
           reporter: github-pr-review
           filter_mode: nofilter
           fail_on_error: true
@@ -66,7 +64,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: reviewdog/action-misspell@v1
         with:
-          github_token: ${{ secrets.HUB_TOKEN }}
+          github_token: ${{ secrets.github_token }}
           locale: "US"
           reporter: github-pr-review
 
@@ -77,7 +75,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: reviewdog/action-languagetool@v1
         with:
-          github_token: ${{ secrets.HUB_TOKEN }}
+          github_token: ${{ secrets.github_token }}
           reporter: github-pr-review
           level: info
           patterns: |


### PR DESCRIPTION
This PR fixes two problems on pull requests from forks:
- [X] Reviewdog failing because the token is not available on forks
- [X] Tests and coverage not running 