### PR TITLE
fix: initialize message fields

### DIFF
--- a/hub.go
+++ b/hub.go
@@ -24,6 +24,10 @@ func New() *Hub {
 
 // Publish will send an event to all the subscribers matching the event name.
 func (h *Hub) Publish(m Message) {
+	if len(h.fields) > 0 && m.Fields == nil {
+		m.Fields = Fields{}
+	}
+
 	for k, v := range h.fields {
 		m.Fields[k] = v
 	}

--- a/hub_test.go
+++ b/hub_test.go
@@ -195,6 +195,20 @@ func testPublishDoesNotPanicWhenSubscriberClosesAfterLookup(t *testing.T, subscr
 	}
 }
 
+func TestPublishInitializesNilMessageFieldsWhenHubHasFields(t *testing.T) {
+	h := New().With(Fields{"source": "test"})
+
+	sub := h.Subscribe(1, "log.*")
+	defer h.Unsubscribe(sub)
+
+	require.NotPanics(t, func() {
+		h.Publish(Message{Name: "log.debug"})
+	})
+
+	msg := <-sub.Receiver
+	require.Equal(t, Fields{"source": "test"}, msg.Fields)
+}
+
 func newMessageCounter(s Subscription) *messageCounter {
 	ms := &messageCounter{sub: s, c: 0}
 	go func(ms *messageCounter) {


### PR DESCRIPTION
## Summary
- initialize nil message fields before applying hub-level fields
- add regression coverage for publishing messages without explicit fields

## Tests
- go test ./...

Closes #17