### PR TITLE
fix: guard subscriber close races

### DIFF
--- a/hub_test.go
+++ b/hub_test.go
@@ -150,6 +150,51 @@ func TestWith(t *testing.T) {
 	require.Falsef(t, ok, "Unsubscribe should close the internal channel, received fields %v", v)
 }
 
+func TestPublishDoesNotPanicWhenNonBlockingSubscriberClosesAfterLookup(t *testing.T) {
+	testPublishDoesNotPanicWhenSubscriberClosesAfterLookup(t, func(h *Hub) Subscription {
+		return h.NonBlockingSubscribe(1, "log.*")
+	})
+}
+
+func TestPublishDoesNotPanicWhenBlockingSubscriberClosesAfterLookup(t *testing.T) {
+	testPublishDoesNotPanicWhenSubscriberClosesAfterLookup(t, func(h *Hub) Subscription {
+		return h.Subscribe(100, "log.*")
+	})
+}
+
+func testPublishDoesNotPanicWhenSubscriberClosesAfterLookup(t *testing.T, subscribe func(*Hub) Subscription) {
+	t.Helper()
+
+	for i := 0; i < 10000; i++ {
+		h := New()
+		sub := subscribe(h)
+		panicCh := make(chan interface{}, 1)
+		done := make(chan struct{})
+
+		go func() {
+			defer close(done)
+			defer func() {
+				if r := recover(); r != nil {
+					panicCh <- r
+				}
+			}()
+
+			for j := 0; j < 100; j++ {
+				h.Publish(Message{Name: "log.debug"})
+			}
+		}()
+
+		h.Unsubscribe(sub)
+		<-done
+
+		select {
+		case p := <-panicCh:
+			require.Failf(t, "Publish panicked", "iteration %d panic: %v", i, p)
+		default:
+		}
+	}
+}
+
 func newMessageCounter(s Subscription) *messageCounter {
 	ms := &messageCounter{sub: s, c: 0}
 	go func(ms *messageCounter) {

--- a/matching_cstrie.go
+++ b/matching_cstrie.go
@@ -528,7 +528,7 @@ func cleanParent(i, parent, parentsParent *iNode, c *csTrieMatcher, word string)
 			}
 
 			if main.tNode != nil {
-				if !contract(parentsParent, parent, c, pMain) {
+				if parentsParent != nil && !contract(parentsParent, parent, c, pMain) {
 					cleanParent(parentsParent, parent, i, c, word)
 				}
 			}

--- a/subscriber.go
+++ b/subscriber.go
@@ -11,11 +11,15 @@ type (
 		ch        chan Message
 		alert     alertFunc
 		onceClose sync.Once
+		mu        sync.RWMutex
+		closed    bool
 	}
 	// blockingSubscriber uses an channel to receive events.
 	blockingSubscriber struct {
 		ch        chan Message
 		onceClose sync.Once
+		mu        sync.RWMutex
+		closed    bool
 	}
 )
 
@@ -35,6 +39,13 @@ func newNonBlockingSubscriber(cap int, alerter alertFunc) *nonBlockingSubscriber
 
 // Set inserts the given Event into the diode.
 func (s *nonBlockingSubscriber) Set(msg Message) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.closed {
+		return
+	}
+
 	select {
 	case s.ch <- msg:
 	default:
@@ -50,6 +61,10 @@ func (s *nonBlockingSubscriber) Ch() <-chan Message {
 // Close will close the internal channel and stop receiving messages.
 func (s *nonBlockingSubscriber) Close() {
 	s.onceClose.Do(func() {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+
+		s.closed = true
 		close(s.ch)
 	})
 }
@@ -67,6 +82,13 @@ func newBlockingSubscriber(cap int) *blockingSubscriber {
 
 // Set will send the message using the channel.
 func (s *blockingSubscriber) Set(msg Message) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.closed {
+		return
+	}
+
 	s.ch <- msg
 }
 
@@ -78,6 +100,10 @@ func (s *blockingSubscriber) Ch() <-chan Message {
 // Close will close the internal channel and stop receiving messages.
 func (s *blockingSubscriber) Close() {
 	s.onceClose.Do(func() {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+
+		s.closed = true
 		close(s.ch)
 	})
 }


### PR DESCRIPTION
## Summary
- guard subscriber Set and Close with RWMutex and a closed flag
- make stale subscribers returned by concurrent Lookup safe to ignore after close
- add regression coverage for blocking and non-blocking subscribers

## Tests
- go test ./...

Closes #16