### PR TITLE
ci: update test workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   test:
-    name: Tests
+    name: Run Tests
     runs-on: ubuntu-latest
     steps:
       - name: Check out code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,32 +1,36 @@
-name: Pull Request CI Check
-on: [push, pull_request]
+name: CI
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
 jobs:
-  build:
-    name: Run Tests
+  test:
+    name: Tests
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.15
-        uses: actions/setup-go@v1
+      - name: Check out code
+        uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
         with:
-          go-version: 1.15
-        id: go
+          go-version: stable
+          cache: true
 
       - name: Go env
         run: go env
 
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
-
-      - name: Setup
-        run: make setup
-
       - name: Tests
-        run: make test
+        run: go test -race -covermode=atomic -coverprofile=coverage.txt -timeout=1m -cover ./...
 
-      - name: Send coverage
-        uses: codecov/codecov-action@v1
+      - name: Upload coverage
+        uses: codecov/codecov-action@v5
         with:
-          file: ./coverage.txt
+          files: ./coverage.txt
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: false

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
 
 permissions:
+  checks: write
   contents: read
   pull-requests: write
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,27 +1,25 @@
-name: Lint
+name: reviewdog
 
 on:
   pull_request:
 
 permissions:
+  checks: write
   contents: read
 
 jobs:
   golangci-lint:
-    name: golangci-lint
+    name: runner / golangci-lint
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v7
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
         with:
-          go-version: stable
-          cache: true
+          fetch-depth: 0
 
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v9
+      - name: golangci-lint
+        uses: reviewdog/action-golangci-lint@v2
         with:
-          version: v2.12
-          args: --config=.golangci.yml -E revive -E errcheck
+          go_version: stable
+          golangci_lint_version: v2.12.2
+          golangci_lint_flags: --config=.golangci.yml -E revive -E errcheck

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,32 +1,39 @@
 name: reviewdog
-on: [pull_request]
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   golangci-lint:
     name: runner / golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
+      - name: Check out code
+        uses: actions/checkout@v7
       - name: golangci-lint
-        uses: docker://reviewdog/action-golangci-lint:v1.6 # Pre-built image
+        uses: reviewdog/action-golangci-lint@v2
         with:
-          github_token: ${{ secrets.github_token }}
-          golangci_lint_flags: "--config=.golangci.yml -D golint -D errcheck"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          golangci_lint_flags: "--config=.golangci.yml -D revive -D errcheck"
           reporter: github-pr-review
 
-  # Use golint via golangci-lint binary with "warning" level.
-  golint:
-    name: runner / golint
+  # Use revive via golangci-lint binary with "error" level.
+  revive:
+    name: runner / revive
     runs-on: ubuntu-latest
     steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
-      - name: golint
-        uses: reviewdog/action-golangci-lint@v1
+      - name: Check out code
+        uses: actions/checkout@v7
+      - name: revive
+        uses: reviewdog/action-golangci-lint@v2
         with:
-          github_token: ${{ secrets.github_token }}
-          golangci_lint_flags: "--disable-all -E golint"
-          tool_name: golint # Change reporter name.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          golangci_lint_flags: "--enable-only=revive"
+          tool_name: revive # Change reporter name.
           level: error
           reporter: github-pr-review
 
@@ -34,13 +41,13 @@ jobs:
     name: runner / errcheck
     runs-on: ubuntu-latest
     steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
+      - name: Check out code
+        uses: actions/checkout@v7
       - name: errcheck
-        uses: reviewdog/action-golangci-lint@v1
+        uses: reviewdog/action-golangci-lint@v2
         with:
-          github_token: ${{ secrets.github_token }}
-          golangci_lint_flags: "--disable-all -E errcheck"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          golangci_lint_flags: "--enable-only=errcheck"
           tool_name: errcheck
           level: warning
           reporter: github-pr-review
@@ -49,10 +56,10 @@ jobs:
     name: runner / staticcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
       - uses: reviewdog/action-staticcheck@v1
         with:
-          github_token: ${{ secrets.github_token }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review
           filter_mode: nofilter
           fail_on_error: true
@@ -61,10 +68,10 @@ jobs:
     name: runner / misspell
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
       - uses: reviewdog/action-misspell@v1
         with:
-          github_token: ${{ secrets.github_token }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           locale: "US"
           reporter: github-pr-review
 
@@ -72,10 +79,10 @@ jobs:
     name: runner / languagetool
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
       - uses: reviewdog/action-languagetool@v1
         with:
-          github_token: ${{ secrets.github_token }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review
           level: info
           patterns: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,4 +22,5 @@ jobs:
         with:
           golangci_lint_version: v2.12.2
           golangci_lint_flags: --config=.golangci.yml -E revive -E errcheck
+          reporter: github-check
           filter_mode: nofilter

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,6 +20,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           golangci_lint_flags: "--config=.golangci.yml -D revive -D errcheck"
           reporter: github-pr-review
+          filter_mode: nofilter
 
   # Use revive via golangci-lint binary with "error" level.
   revive:
@@ -36,6 +37,7 @@ jobs:
           tool_name: revive # Change reporter name.
           level: error
           reporter: github-pr-review
+          filter_mode: nofilter
 
   errcheck:
     name: runner / errcheck
@@ -51,6 +53,7 @@ jobs:
           tool_name: errcheck
           level: warning
           reporter: github-pr-review
+          filter_mode: nofilter
 
   staticcheck:
     name: runner / staticcheck

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
 
 permissions:
-  checks: write
   contents: read
 
 jobs:
@@ -22,5 +21,5 @@ jobs:
         with:
           golangci_lint_version: v2.12.2
           golangci_lint_flags: --config=.golangci.yml -E revive -E errcheck
-          reporter: github-check
+          reporter: local
           filter_mode: nofilter

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,6 +20,6 @@ jobs:
       - name: golangci-lint
         uses: reviewdog/action-golangci-lint@v2
         with:
-          go_version: stable
           golangci_lint_version: v2.12.2
           golangci_lint_flags: --config=.golangci.yml -E revive -E errcheck
+          filter_mode: nofilter

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,94 +1,27 @@
-name: reviewdog
+name: Lint
 
 on:
   pull_request:
 
 permissions:
-  checks: write
   contents: read
-  pull-requests: write
 
 jobs:
   golangci-lint:
-    name: runner / golangci-lint
+    name: golangci-lint
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v7
-      - name: golangci-lint
-        uses: reviewdog/action-golangci-lint@v2
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          golangci_lint_flags: "--config=.golangci.yml -D revive -D errcheck"
-          reporter: github-pr-check
-          filter_mode: nofilter
 
-  # Use revive via golangci-lint binary with "error" level.
-  revive:
-    name: runner / revive
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v7
-      - name: revive
-        uses: reviewdog/action-golangci-lint@v2
+      - name: Set up Go
+        uses: actions/setup-go@v6
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          golangci_lint_flags: "--enable-only=revive"
-          tool_name: revive # Change reporter name.
-          level: error
-          reporter: github-pr-check
-          filter_mode: nofilter
+          go-version: stable
+          cache: true
 
-  errcheck:
-    name: runner / errcheck
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v7
-      - name: errcheck
-        uses: reviewdog/action-golangci-lint@v2
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v9
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          golangci_lint_flags: "--enable-only=errcheck"
-          tool_name: errcheck
-          level: warning
-          reporter: github-pr-check
-          filter_mode: nofilter
-
-  staticcheck:
-    name: runner / staticcheck
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: reviewdog/action-staticcheck@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          reporter: github-pr-check
-          filter_mode: nofilter
-          fail_on_error: true
-
-  misspell:
-    name: runner / misspell
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: reviewdog/action-misspell@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          locale: "US"
-          reporter: github-pr-check
-
-  languagetool:
-    name: runner / languagetool
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: reviewdog/action-languagetool@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          reporter: github-pr-check
-          level: info
-          patterns: |
-            **/*.md
-            !**/testdata/**
+          version: v2.12
+          args: --config=.golangci.yml -E revive -E errcheck

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -23,3 +23,22 @@ jobs:
           golangci_lint_flags: --config=.golangci.yml -E revive -E errcheck
           reporter: local
           filter_mode: nofilter
+
+  errcheck:
+    name: runner / errcheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: errcheck
+        uses: reviewdog/action-golangci-lint@v2
+        with:
+          golangci_lint_version: v2.12.2
+          golangci_lint_flags: --enable-only=errcheck
+          tool_name: errcheck
+          level: warning
+          reporter: local
+          filter_mode: nofilter

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           golangci_lint_flags: "--config=.golangci.yml -D revive -D errcheck"
-          reporter: github-pr-review
+          reporter: github-pr-check
           filter_mode: nofilter
 
   # Use revive via golangci-lint binary with "error" level.
@@ -36,7 +36,7 @@ jobs:
           golangci_lint_flags: "--enable-only=revive"
           tool_name: revive # Change reporter name.
           level: error
-          reporter: github-pr-review
+          reporter: github-pr-check
           filter_mode: nofilter
 
   errcheck:
@@ -52,7 +52,7 @@ jobs:
           golangci_lint_flags: "--enable-only=errcheck"
           tool_name: errcheck
           level: warning
-          reporter: github-pr-review
+          reporter: github-pr-check
           filter_mode: nofilter
 
   staticcheck:
@@ -63,7 +63,7 @@ jobs:
       - uses: reviewdog/action-staticcheck@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          reporter: github-pr-review
+          reporter: github-pr-check
           filter_mode: nofilter
           fail_on_error: true
 
@@ -76,7 +76,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           locale: "US"
-          reporter: github-pr-review
+          reporter: github-pr-check
 
   languagetool:
     name: runner / languagetool
@@ -86,7 +86,7 @@ jobs:
       - uses: reviewdog/action-languagetool@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          reporter: github-pr-review
+          reporter: github-pr-check
           level: info
           patterns: |
             **/*.md

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,88 +1,60 @@
-# This file contains all available configuration options
-# with their default values.
-
-# options for analysis running
-run:
-  # timeout for analysis, e.g. 30s, 5m, default is 1m
-  deadline: 10m
-
-# output configuration options
-output:
-  # colored-line-number|line-number|json|tab|checkstyle, default is "colored-line-number"
-  format: colored-line-number
-
-  # print lines of code with issue, default is true
-  print-issued-lnes: true
-
-  # print linter name in the end of issue text, default is true
-  print-linter-name: true
-
-# all available settings of specific linters
-linters-settings:
-  golint:
-    # minimal confidence for issues, default is 0.8
-    min-confidence: 0.8
-  gocyclo:
-    # minimal code complexity to report, 30 by default (but we recommend 10-20)
-    min-complexity: 20
-  maligned:
-    # print struct with more effective memory layout or not, false by default
-    suggest-new: true
-  goimports:
-    local-prefixes: github.com/empregoligado/rabbids
-  depguard:
-    list-type: blacklist
-    include-go-root: false
-    packages:
-      - github.com/davecgh/go-spew/spew
-  lll:
-    # max line length, lines longer will be reported. Default is 120.
-    # '\t' is counted as 1 character by default, and can be changed with the tab-width option
-    line-length: 130
-    # tab width in spaces. Default to 1.
-    tab-width: 4
-  unused:
-    # treat code as a program (not a library) and report unused exported identifiers; default is false.
-    # XXX: if you enable this setting, unused will report a lot of false-positives in text editors:
-    # if it's called for subdir of a project it can't find funcs usages. All text editor integrations
-    # with golangci-lint call it on a directory with the changed file.
-    check-exported: false
-  unparam:
-    # Inspect exported functions, default is false. Set to true if no external program/library imports your code.
-    # XXX: if you enable this setting, unparam will report a lot of false-positives in text editors:
-    # if it's called for subdir of a project it can't find external interfaces. All text editor integrations
-    # with golangci-lint call it on a directory with the changed file.
-    check-exported: false
-  wsl:
-    # If true append is only allowed to be cuddled if appending value is
-    # matching variables, fields or types on line above. Default is true.
-    strict-append: true
-    # Allow calls and assignments to be cuddled as long as the lines have any
-    # matching variables, fields or types. Default is true.
-    allow-assign-and-call: true
-    # Allow multiline assignments to be cuddled. Default is true.
-    allow-multiline-assign: true
-    # Allow declarations (var) to be cuddled.
-    allow-cuddle-declarations: true
-    # Allow trailing comments in ending of blocks
-    allow-trailing-comment: false
-    # Force newlines in end of case at this limit (0 = never).
-    force-case-trailing-whitespace: 0
+version: "2"
 
 linters:
-  enable-all: true
+  default: standard
   disable:
-    - maligned
-    - prealloc
-    - gosec
     - gochecknoglobals
-    - goimports
-    - gomnd
+    - gosec
+    - mnd
+    - prealloc
+  settings:
+    depguard:
+      rules:
+        main:
+          list-mode: lax
+          deny:
+            - pkg: github.com/davecgh/go-spew/spew
+              desc: not allowed
+    gocyclo:
+      min-complexity: 20
+    lll:
+      line-length: 130
+      tab-width: 4
+    revive:
+      confidence: 0.8
+    unparam:
+      check-exported: false
+    wsl:
+      strict-append: true
+      allow-assign-and-call: true
+      allow-multiline-assign: true
+      allow-cuddle-declarations: true
+      allow-trailing-comment: false
+      force-case-trailing-whitespace: 0
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 
-issues:
-  # List of regexps of issue texts to exclude, empty list by default.
-  # But independently from this option we use default exclude patterns,
-  # it can be disabled by `exclude-use-default: false`. To list all
-  # excluded by default patterns execute `golangci-lint run --help`
-  # exclude:
-  # - newHTTP - result 1 (error) is always nil
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/empregoligado/rabbids
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/hub.go
+++ b/hub.go
@@ -5,7 +5,7 @@ package hub
 const AlertTopic = "hub.subscription.messageslost"
 
 type (
-	//Hub is a component that provides publish and subscribe capabilities for messages.
+	// Hub is a component that provides publish and subscribe capabilities for messages.
 	// Every message has a Name used to route them to subscribers and this can be used like RabbitMQ topics exchanges.
 	// Where every word is separated by dots `.` and you can use `*` as a wildcard.
 	Hub struct {

--- a/throughput_test.go
+++ b/throughput_test.go
@@ -41,7 +41,7 @@ func setupTopics() {
 	for i := 0; i < numMsgs; i++ {
 		topic := topics[i%numSubs]
 		msgs[i] = Message{
-			Name: strings.Replace(topic, "*", strconv.Itoa(rand.Intn(10)), -1),
+			Name: strings.ReplaceAll(topic, "*", strconv.Itoa(rand.Intn(10))),
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- update GitHub Actions test workflow to current checkout/setup-go/codecov actions
- migrate reviewdog golangci jobs to action-golangci-lint v2 and replace golint with revive
- migrate golangci-lint config to v2 syntax

## Verification
- ruby YAML parse for workflow and golangci config files
- golangci-lint config verify --config .golangci.yml
- golangci-lint run --config .golangci.yml
- golangci-lint run --enable-only=revive ./...
- golangci-lint run --enable-only=errcheck ./...
- go test -race -covermode=atomic -coverprofile=coverage.txt -timeout=1m -cover ./...